### PR TITLE
Q&A Improvements

### DIFF
--- a/src/assets/thumbs-up-active.svg
+++ b/src/assets/thumbs-up-active.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="orange" xmlns="http://www.w3.org/2000/svg">
+  <path d="M3 10C3 9.44772 3.44772 9 4 9H7V21H4C3.44772 21 3 20.5523 3 20V10Z" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M7 11V19L8.9923 20.3282C9.64937 20.7662 10.4214 21 11.2111 21H16.4586C17.9251 21 19.1767 19.9398 19.4178 18.4932L20.6119 11.3288C20.815 10.1097 19.875 9 18.6391 9H14" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M14 9L14.6872 5.56415C14.8659 4.67057 14.3512 3.78375 13.4867 3.49558V3.49558C12.6336 3.21122 11.7013 3.59741 11.2992 4.4017L8 11H7" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/thumbs-up.svg
+++ b/src/assets/thumbs-up.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="gray" xmlns="http://www.w3.org/2000/svg">
+  <path d="M3 10C3 9.44772 3.44772 9 4 9H7V21H4C3.44772 21 3 20.5523 3 20V10Z" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M7 11V19L8.9923 20.3282C9.64937 20.7662 10.4214 21 11.2111 21H16.4586C17.9251 21 19.1767 19.9398 19.4178 18.4932L20.6119 11.3288C20.815 10.1097 19.875 9 18.6391 9H14" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M14 9L14.6872 5.56415C14.8659 4.67057 14.3512 3.78375 13.4867 3.49558V3.49558C12.6336 3.21122 11.7013 3.59741 11.2992 4.4017L8 11H7" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/structure/AppHeader.vue
+++ b/src/components/structure/AppHeader.vue
@@ -13,13 +13,13 @@
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
           <div class="me-auto">
             <RouterLink to="/all-talks" class="btn btn-secondary me-lg-2 mt-2 mt-lg-0 d-block d-lg-inline" @click="collapseNavbar">All Talks</RouterLink>
-            <template v-if="authenticationStore.qaadmin">
+            <a :href="lamaPollUrl" target="_blank" class="btn btn-secondary me-lg-2 mt-2 mt-lg-0 d-block d-lg-inline" @click="collapseNavbar" v-if="lamaPollUrl">
+              Conference Feedback <img class="external-link-icon" src="@/assets/external-link.svg" alt=""/>
+            </a>
+            <template v-if="authenticationStore.qaadmin || authenticationStore.admin">
               <RouterLink to="/qa" class="btn btn-warning me-lg-2 mt-2 mt-lg-0 d-block d-lg-inline" @click="collapseNavbar">Q&amp;A View</RouterLink>
             </template>
             <template v-else>
-              <a :href="lamaPollUrl" target="_blank" class="btn btn-secondary me-lg-2 mt-2 mt-lg-0 d-block d-lg-inline" @click="collapseNavbar" v-if="lamaPollUrl">
-                Conference Feedback <img class="external-link-icon" src="@/assets/external-link.svg" alt=""/>
-              </a>
               <a href="mailto:info@adapt.to?subject=Lightning Talk Proposal" class="btn btn-secondary me-lg-2 mt-2 mt-lg-0 d-block d-lg-inline" @click="collapseNavbar" v-if="lamaPollUrl">
                 Submit Lightning Talk
               </a>
@@ -37,7 +37,11 @@
                 <li><RouterLink to="/admin/statistics" class="dropdown-item">Statistics</RouterLink></li>
                 <li><RouterLink to="/admin/kpi" class="dropdown-item">KPI</RouterLink></li>
                 <li><hr class="dropdown-divider"></li>
-                <li><RouterLink to="/qa" class="dropdown-item">Q&amp;A View</RouterLink></li>
+                <li>
+                  <a href="mailto:info@adapt.to?subject=Lightning Talk Proposal" class="dropdown-item" @click="collapseNavbar" v-if="lamaPollUrl">
+                    Submit Lightning Talk
+                  </a>
+                </li>
               </ul>
             </li>
             <li class="nav-item">

--- a/src/components/talk/TalkDiscussion.vue
+++ b/src/components/talk/TalkDiscussion.vue
@@ -112,7 +112,7 @@ function showQA() {
     "tab-discussion tab-qa"
     "chat qa";
   grid-template-rows: auto 1fr;
-  grid-template-columns: 60% 40%;
+  grid-template-columns: 50% 50%;
   overflow-y: auto;
   .tab-selection {
     grid-area: tab-selection;

--- a/src/components/talk/TalkQA.vue
+++ b/src/components/talk/TalkQA.vue
@@ -3,7 +3,7 @@
     <div class="qa-window">
       <template v-for="(message, index) in messageWithoutReplies" :key="message.id">
         <div class="message-container">
-          <div class="index">{{index+1}}.</div>
+          <div class="index">{{message.entryIndex ? `${message.entryIndex}.` : ''}}</div>
           <div class="message-and-replies">
             <MessageDisplay :message="message" :read-only="qaBigView"
                 @message-clicked="messageClicked(message)"/>
@@ -229,9 +229,9 @@ function sendNewMessage(messageUsername?: string) : void {
   const id = uuidv4()
   const text = messageText.value
   const replyTo = replyToMessage.value?.id
-  socket.emit('qaEntry', { id, talkId: props.talk.id, text, anonymous: messageAnonymous.value, replyTo}, result => {
+  socket.emit('qaEntry', { id, talkId: props.talk.id, text, anonymous: messageAnonymous.value, replyTo}, (result, entryIndex) => {
     if (result.success) {
-      addMessage({id, date: new Date(), userid: authenticationStore.userid, username: messageUsername, text, replyTo})
+      addMessage({id, date: new Date(), userid: authenticationStore.userid, username: messageUsername, text, entryIndex, replyTo})
     }
     else if (result.error) {
       errorMessagesStore.add(`Unable to create QA entry: ${result.error}`)

--- a/src/components/talk/TalkQA.vue
+++ b/src/components/talk/TalkQA.vue
@@ -60,7 +60,7 @@
           <p class="fst-italic">
             Please write briefly and concisely.
           </p>
-          <TextAreaEmojiPicker class="textarea" v-model="messageText" :allow-enter="true"/>
+          <TextAreaEmojiPicker class="textarea" v-model="messageText" :allow-enter="true" :max-length="1000"/>
           <div class="mt-3 form-check">
             <input type="checkbox" class="form-check-input" id="qaEntryAnonymous" v-model="messageAnonymous">
             <label class="form-check-label" for="qaEntryAnonymous">Anonymous (without user name)</label>
@@ -94,7 +94,7 @@
           <div class="reply-to-question" v-if="replyToMessage">
             {{replyToMessage.text}}
           </div>
-          <TextAreaEmojiPicker class="textarea" v-model="messageText" :allow-enter="true"/>
+          <TextAreaEmojiPicker class="textarea" v-model="messageText" :allow-enter="true" :max-length="1000"/>
           <div v-if="authenticationStore.admin" class="form-check mt-3">
             <input type="checkbox" class="form-check-input" id="qaEntryReplyHighlight" v-model="messageHighlight">
             <label class="form-check-label" for="qaEntryReplyHighlight">Highlight</label>

--- a/src/components/talk/TalkQA.vue
+++ b/src/components/talk/TalkQA.vue
@@ -19,6 +19,7 @@
               </div>
             </div>
           </div>
+          <QAEntryLike :message="message" class="like-button"/>
           <button class="btn btn-outline-secondary btn-sm reply-button" @click="addReply(message)" v-if="!qaBigView">Reply</button>
           <button class="btn btn-secondary btn-lg" @click="markAnswered(message)" v-else>{{message.answered ? 'Unanswer' : 'Answered'}}</button>
         </div>
@@ -120,6 +121,7 @@ import { useErrorMessagesStore } from '@/stores/errorMessages'
 import MessageAnswerFilter from '@/services/MessageAnswerFilter'
 import MessageDisplayExport from './MessageDisplayExport.vue'
 import copyElementToClipboard from '@/util/copyElementToClipboard'
+import QAEntryLike from '../talkQA/QAEntryLike.vue'
 
 const props = defineProps<{
   talk: Talk,
@@ -304,6 +306,7 @@ onMounted(() => {
       message.text = updatedMessage.text
       message.highlight = updatedMessage.highlight
       message.answered = updatedMessage.answered
+      message.likeUserIds = updatedMessage.likeUserIds
     }
   })
   socket.on('qaEntryDelete', id => {
@@ -374,10 +377,14 @@ onUnmounted(() => {
       background-color: unset;
     }
   }
+  .like-button {
+    margin-left: 15px;
+    margin-right: 0;
+  }
   .reply-button {
     height: 40px;
+    margin-left: 5px;
     margin-right: 0;
-    margin-left: 15px;
   }
   .reply-list {
     margin-left: 20px;

--- a/src/components/talk/TalkQA.vue
+++ b/src/components/talk/TalkQA.vue
@@ -19,7 +19,7 @@
               </div>
             </div>
           </div>
-          <QAEntryLike :message="message" class="like-button"/>
+          <QAEntryLike :id="message.id" :likeUserIds="message.likeUserIds" :key="(message.likeUserIds??[]).length" class="like-button" :disabled="qaBigView"/>
           <button class="btn btn-outline-secondary btn-sm reply-button" @click="addReply(message)" v-if="!qaBigView">Reply</button>
           <button class="btn btn-secondary btn-lg" @click="markAnswered(message)" v-else>{{message.answered ? 'Unanswer' : 'Answered'}}</button>
         </div>

--- a/src/components/talk/TalkQA.vue
+++ b/src/components/talk/TalkQA.vue
@@ -57,6 +57,9 @@
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
+          <p class="fst-italic">
+            Please write briefly and concisely.
+          </p>
           <TextAreaEmojiPicker class="textarea" v-model="messageText" :allow-enter="true"/>
           <div class="mt-3 form-check">
             <input type="checkbox" class="form-check-input" id="qaEntryAnonymous" v-model="messageAnonymous">

--- a/src/components/talk/TalkQA.vue
+++ b/src/components/talk/TalkQA.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="qa-container">
     <div class="qa-window">
-      <template v-for="(message, index) in messageWithoutReplies" :key="message.id">
+      <template v-for="message in messageWithoutReplies" :key="message.id">
         <div class="message-container">
           <div class="index">{{message.entryIndex ? `${message.entryIndex}.` : ''}}</div>
           <div class="message-and-replies">
@@ -21,7 +21,7 @@
           </div>
           <QAEntryLike :id="message.id" :likeUserIds="message.likeUserIds" :key="(message.likeUserIds??[]).length" class="like-button" :disabled="qaBigView"/>
           <button class="btn btn-outline-secondary btn-sm reply-button" @click="addReply(message)" v-if="!qaBigView">Reply</button>
-          <button class="btn btn-secondary btn-lg" @click="markAnswered(message)" v-else>{{message.answered ? 'Unanswer' : 'Answered'}}</button>
+          <button class="btn btn-secondary btn-lg answer-button" @click="markAnswered(message)" v-else>{{message.answered ? 'Unanswer' : 'Answered'}}</button>
         </div>
       </template>
 
@@ -388,11 +388,16 @@ onUnmounted(() => {
   .like-button {
     margin-left: 15px;
     margin-right: 0;
+    margin-top: 0px;
   }
   .reply-button {
     height: 40px;
     margin-left: 5px;
     margin-right: 0;
+    margin-top: 0;
+  }
+  .answer-button {
+    margin-top: 0;
   }
   .reply-list {
     margin-left: 20px;

--- a/src/components/talk/TalkQA.vue
+++ b/src/components/talk/TalkQA.vue
@@ -122,19 +122,27 @@ import MessageAnswerFilter from '@/services/MessageAnswerFilter'
 import MessageDisplayExport from './MessageDisplayExport.vue'
 import copyElementToClipboard from '@/util/copyElementToClipboard'
 import QAEntryLike from '../talkQA/QAEntryLike.vue'
+import MessageSortOrder from '@/services/MessageSortOrder'
 
 const props = defineProps<{
   talk: Talk,
   qaBigView?: boolean,
-  messageAnswerFilter?: MessageAnswerFilter
+  messageAnswerFilter?: MessageAnswerFilter,
+  messageSortOrder?: MessageSortOrder
 }>()
 
 const authenticationStore = useAuthenticationStore()
 const errorMessagesStore = useErrorMessagesStore()
 const messages = ref([] as Message[])
-const messageWithoutReplies = computed(() => messages.value
-    .filter(item => item.replyTo == undefined)
-    .filter(item => item.answered && props.messageAnswerFilter != MessageAnswerFilter.UNANSWERED || !item.answered && props.messageAnswerFilter != MessageAnswerFilter.ANSWERED))
+const messageWithoutReplies = computed(() => {
+  const filteredMessages = messages.value
+      .filter(item => item.replyTo == undefined)
+      .filter(item => item.answered && props.messageAnswerFilter != MessageAnswerFilter.UNANSWERED || !item.answered && props.messageAnswerFilter != MessageAnswerFilter.ANSWERED)
+  if (props.messageSortOrder == MessageSortOrder.VOTES) {
+    filteredMessages.sort((msg1, msg2) => (msg2.likeUserIds?.length ?? 0) - (msg1.likeUserIds?.length ?? 0))
+  }
+  return filteredMessages
+})
 
 const messageText = ref('')
 const messageAnonymous = ref(false)

--- a/src/components/talkQA/QAEntryLike.vue
+++ b/src/components/talkQA/QAEntryLike.vue
@@ -1,28 +1,29 @@
 <template>
   <button class="btn btn-sm btn-outline-secondary" @click="likeToggle">
-    <img v-if="userLiked" src="@/assets/thumbs-up-active.svg" class="thumbs-up">
-    <img v-else src="@/assets/thumbs-up.svg" class="thumbs-up">
-    <div class="count">{{likeUserIds.length}}</div>
+    <img v-if="userLiked" src="@/assets/thumbs-up-active.svg" alt="Thumbs up" class="thumbs-up">
+    <img v-else src="@/assets/thumbs-up.svg" alt="Thumbs up" class="thumbs-up">
+    <div class="count" :class="{hasVotes:likeCount>0}">{{likeCount}}</div>
   </button>
 </template>
 
 <script setup lang="ts">
-import type Message from '@/services/Message'
 import { useAuthenticationStore } from '@/stores/authentication'
 import { useErrorMessagesStore } from '@/stores/errorMessages'
-import { computed, ref } from 'vue';
+import { computed, ref } from 'vue'
 import socket from '@/util/socket'
 
 const props = defineProps<{
-  message: Message
+  id: string
+  likeUserIds?: string[]
 }>()
 
 const authenticationStore = useAuthenticationStore()
 const errorMessagesStore = useErrorMessagesStore()
 
 const userId = authenticationStore.userid
-const likeUserIds = ref(props.message.likeUserIds ?? [])
+const likeUserIds = ref(props.likeUserIds ?? [])
 const userLiked = computed(() => likeUserIds.value.includes(userId))
+const likeCount = computed(() => likeUserIds.value.length)
 
 function likeToggle() : void {
   if (likeUserIds.value.includes(userId)) {
@@ -31,7 +32,7 @@ function likeToggle() : void {
   else {
     likeUserIds.value.push(userId)
   }
-  socket.emit('qaEntryLike', { id:props.message.id }, result => {
+  socket.emit('qaEntryLike', { id:props.id }, result => {
     if (result.error) {
       errorMessagesStore.add(`Unable to like/unlike QA entry: ${result.error}`)
     }
@@ -42,5 +43,8 @@ function likeToggle() : void {
 <style lang="scss" scoped>
 .thumbs-up {
   height: 1.5rem;
+}
+.count.hasVotes {
+  color: #fff;
 }
 </style>

--- a/src/components/talkQA/QAEntryLike.vue
+++ b/src/components/talkQA/QAEntryLike.vue
@@ -1,0 +1,46 @@
+<template>
+  <button class="btn btn-sm btn-outline-secondary" @click="likeToggle">
+    <img v-if="userLiked" src="@/assets/thumbs-up-active.svg" class="thumbs-up">
+    <img v-else src="@/assets/thumbs-up.svg" class="thumbs-up">
+    <div class="count">{{likeUserIds.length}}</div>
+  </button>
+</template>
+
+<script setup lang="ts">
+import type Message from '@/services/Message'
+import { useAuthenticationStore } from '@/stores/authentication'
+import { useErrorMessagesStore } from '@/stores/errorMessages'
+import { computed, ref } from 'vue';
+import socket from '@/util/socket'
+
+const props = defineProps<{
+  message: Message
+}>()
+
+const authenticationStore = useAuthenticationStore()
+const errorMessagesStore = useErrorMessagesStore()
+
+const userId = authenticationStore.userid
+const likeUserIds = ref(props.message.likeUserIds ?? [])
+const userLiked = computed(() => likeUserIds.value.includes(userId))
+
+function likeToggle() : void {
+  if (likeUserIds.value.includes(userId)) {
+    likeUserIds.value = likeUserIds.value.filter(id => id != userId)
+  }
+  else {
+    likeUserIds.value.push(userId)
+  }
+  socket.emit('qaEntryLike', { id:props.message.id }, result => {
+    if (result.error) {
+      errorMessagesStore.add(`Unable to like/unlike QA entry: ${result.error}`)
+    }
+  })
+}
+</script>
+
+<style lang="scss" scoped>
+.thumbs-up {
+  height: 1.5rem;
+}
+</style>

--- a/src/components/talkQA/TalkQABigView.vue
+++ b/src/components/talkQA/TalkQABigView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="qa-big-view">
-    <TalkQA :talk="talk" :qa-big-view="true" :message-answer-filter="messageAnswerFilter"/>
+    <TalkQA :talk="talk" :qa-big-view="true" :messageAnswerFilter="messageAnswerFilter" :messageSortOrder="messageSortOrder"/>
   </div>
 </template>
 
@@ -10,10 +10,12 @@ import TalkQA from '../talk/TalkQA.vue'
 import { onMounted, onUnmounted } from 'vue'
 import socket from '@/util/socket'
 import type MessageAnswerFilter from '@/services/MessageAnswerFilter'
+import type MessageSortOrder from '@/services/MessageSortOrder'
 
 const props = defineProps<{
   talk: Talk,
-  messageAnswerFilter: MessageAnswerFilter
+  messageAnswerFilter: MessageAnswerFilter,
+  messageSortOrder: MessageSortOrder
 }>()
 
 onMounted(() => {

--- a/src/services/Message.ts
+++ b/src/services/Message.ts
@@ -4,6 +4,7 @@ export default interface Message {
   userid: string
   username?: string
   text: string
+  entryIndex?: number
   replyTo?: string
   highlight?: boolean
   answered?: boolean

--- a/src/services/Message.ts
+++ b/src/services/Message.ts
@@ -7,4 +7,5 @@ export default interface Message {
   replyTo?: string
   highlight?: boolean
   answered?: boolean
+  likeUserIds?: string[]
 }

--- a/src/services/MessageSortOrder.ts
+++ b/src/services/MessageSortOrder.ts
@@ -1,0 +1,5 @@
+enum MessageSortOrder {
+  CHRONOLOGICAL = 'chronological',
+  VOTES = 'votes'
+}
+export default MessageSortOrder

--- a/src/util/socket.types.ts
+++ b/src/util/socket.types.ts
@@ -27,7 +27,7 @@ export interface ClientToServerEvents {
   message: (message: MessageToServer, callback: (result: OperationResult) => void) => void
   messageUpdate: (message: MessageToServer, callback: (result: OperationResult) => void) => void
   messageDelete: (id: string, callback: (result: OperationResult) => void) => void
-  qaEntry: (qaEntry: QAEntryToServer, callback: (result: OperationResult) => void) => void
+  qaEntry: (qaEntry: QAEntryToServer, callback: (result: OperationResult, entryIndex?: number) => void) => void
   qaEntryUpdate: (qaEntry: QAEntryToServer, callback: (result: OperationResult) => void) => void
   qaEntryUpdateAnswered: (answered: QAEntryAnsweredToServer, callback: (result: OperationResult) => void) => void
   qaEntryDelete: (id: string, callback: (result: OperationResult) => void) => void
@@ -102,6 +102,7 @@ export interface QAEntryFromServer {
   userid: string
   username?: string
   text: string
+  entryIndex: number
   replyTo?: string
   highlight?: boolean
   answered?: boolean

--- a/src/util/socket.types.ts
+++ b/src/util/socket.types.ts
@@ -29,8 +29,9 @@ export interface ClientToServerEvents {
   messageDelete: (id: string, callback: (result: OperationResult) => void) => void
   qaEntry: (qaEntry: QAEntryToServer, callback: (result: OperationResult) => void) => void
   qaEntryUpdate: (qaEntry: QAEntryToServer, callback: (result: OperationResult) => void) => void
-  qaEntryUpdateAnswered: (qaEntry: QAEntryAnsweredToServer, callback: (result: OperationResult) => void) => void
+  qaEntryUpdateAnswered: (answered: QAEntryAnsweredToServer, callback: (result: OperationResult) => void) => void
   qaEntryDelete: (id: string, callback: (result: OperationResult) => void) => void
+  qaEntryLike: (like: QAEntryLikeToServer, callback: (result: OperationResult) => void) => void
   adminGetLoginCodes: () => void
   adminGetUsers: () => void
   adminUpdateUser: (user: UserUpdate, callback: (result: OperationResult) => void) => void
@@ -91,6 +92,10 @@ export interface QAEntryAnsweredToServer {
   answered?: boolean
 }
 
+export interface QAEntryLikeToServer {
+  id: string
+}
+
 export interface QAEntryFromServer {
   id: string
   date: Date
@@ -100,6 +105,7 @@ export interface QAEntryFromServer {
   replyTo?: string
   highlight?: boolean
   answered?: boolean
+  likeUserIds: string[]
 }
 
 export interface LoginCode {

--- a/src/views/TalkQAView.vue
+++ b/src/views/TalkQAView.vue
@@ -3,6 +3,12 @@
     <div class="title mb-1">
       <h4>{{talk.title}}</h4>
       <div class="btn-group">
+        <button class="btn btn-outline-secondary" :class="{active:messageSortOrder==MessageSortOrder.CHRONOLOGICAL}"
+            @click="messageSortOrder = MessageSortOrder.CHRONOLOGICAL">Chronological</button>
+        <button class="btn btn-outline-secondary" :class="{active:messageSortOrder==MessageSortOrder.VOTES}"
+            @click="messageSortOrder = MessageSortOrder.VOTES">Votes</button>
+      </div>
+      <div class="btn-group">
         <button class="btn btn-outline-secondary" :class="{active:messageAnswerFilter==MessageAnswerFilter.UNANSWERED}"
             @click="messageAnswerFilter = MessageAnswerFilter.UNANSWERED">Unanswered</button>
         <button class="btn btn-outline-secondary" :class="{active:messageAnswerFilter==MessageAnswerFilter.ANSWERED}"
@@ -10,13 +16,14 @@
       </div>
       <RouterLink to="/" class="btn">✕</RouterLink>
     </div>
-    <TalkQABigView :talk="talk" :message-answer-filter="messageAnswerFilter" class="content" :key="talk.id"/>
+    <TalkQABigView :talk="talk" :messageAnswerFilter="messageAnswerFilter" :messageSortOrder="messageSortOrder" class="content" :key="talk.id"/>
   </div>
 </template>
 
 <script setup lang="ts">
 import TalkQABigView from '@/components/talkQA/TalkQABigView.vue'
 import MessageAnswerFilter from '@/services/MessageAnswerFilter'
+import MessageSortOrder from '@/services/MessageSortOrder'
 import TalkManager from '@/services/TalkManager'
 import { useCurrentTalkStore } from '@/stores/currentTalk'
 import { computed, ref } from 'vue'
@@ -26,6 +33,7 @@ const talkManager = new TalkManager()
 const currentTalkId = computed(() => useCurrentTalkStore().talkId)
 const talk = computed(() => talkManager.getTalk(currentTalkId.value))
 const messageAnswerFilter = ref(MessageAnswerFilter.UNANSWERED)
+const messageSortOrder = ref(MessageSortOrder.CHRONOLOGICAL)
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
* Allow users to like Q&A entries and show number of likes (to identify most relevant entries for moderator)
* Split screen 50/50 between messages and Q&A
* Allow to sort Q&A view chronological or by votes
* Use persistent question number for Q&A entries
* Increase Q&A entry text limit to 1000 chars

Depends on https://github.com/adaptto-live/adaptto-live-server/pull/14