### PR TITLE
Improve Q&A View Usability with talk likes changing in real time

### DIFF
--- a/src/components/talk/TalkQA.vue
+++ b/src/components/talk/TalkQA.vue
@@ -9,10 +9,10 @@
                 @message-clicked="messageClicked(message)"/>
             <div class="reply-list">
               <button v-if="qaBigView && !isShowRepliesInQABigView(message) && getReplies(message).length > 0"
-                class="btn btn-sm btn-secondary" @click="showRepliesInqaBigView(message, true)">
+                class="btn btn-sm btn-secondary" @click="showRepliesInQABigView(message, true)">
                 {{getReplies(message).length}} Answers
               </button>
-              <div v-else @click="showRepliesInqaBigView(message, false)">
+              <div v-else @click="showRepliesInQABigView(message, false)">
                 <MessageDisplay v-for="replyMessage in getReplies(message)" :key="replyMessage.id"
                     :message="replyMessage" :read-only="qaBigView"
                     @message-clicked="messageClicked(replyMessage, message)"/>
@@ -115,7 +115,7 @@
 <script setup lang="ts">
 import { useAuthenticationStore } from '@/stores/authentication'
 import type { Talk } from '@/stores/talks'
-import { onMounted, onUnmounted, ref, computed } from 'vue'
+import { onMounted, onUnmounted, ref, computed, watch } from 'vue'
 import { v4 as uuidv4 } from 'uuid'
 import socket from '@/util/socket'
 import type Message from '@/services/Message'
@@ -139,13 +139,24 @@ const props = defineProps<{
 const authenticationStore = useAuthenticationStore()
 const errorMessagesStore = useErrorMessagesStore()
 const messages = ref([] as Message[])
+const likeUserIdsPerMessageIdSnapshot = ref(undefined as Map<string, number>|undefined)
+
 const messageWithoutReplies = computed(() => {
   const filteredMessages = messages.value
       .filter(item => item.replyTo == undefined)
       .filter(item => item.answered && props.messageAnswerFilter != MessageAnswerFilter.UNANSWERED || !item.answered && props.messageAnswerFilter != MessageAnswerFilter.ANSWERED)
+  
   if (props.messageSortOrder == MessageSortOrder.VOTES) {
-    filteredMessages.sort((msg1, msg2) => (msg2.likeUserIds?.length ?? 0) - (msg1.likeUserIds?.length ?? 0))
+    // store current like counts to keep this order consistent until the order is refreshed
+    if (!likeUserIdsPerMessageIdSnapshot.value) {
+      likeUserIdsPerMessageIdSnapshot.value = new Map<string, number>()
+      filteredMessages.forEach(message => {
+        likeUserIdsPerMessageIdSnapshot.value?.set(message.id, message.likeUserIds?.length ?? 0)
+      })
+    }
+    filteredMessages.sort((msg1, msg2) => (likeUserIdsPerMessageIdSnapshot.value?.get(msg2.id) ?? 0) - (likeUserIdsPerMessageIdSnapshot.value?.get(msg1.id) ?? 0))
   }
+  
   return filteredMessages
 })
 
@@ -168,7 +179,7 @@ function isShowRepliesInQABigView(message: Message) {
   return qaBigViewShowRepliesForMessage.value.includes(message.id)
 }
 
-function showRepliesInqaBigView(message: Message, show: boolean) {
+function showRepliesInQABigView(message: Message, show: boolean) {
   if (show) {
     qaBigViewShowRepliesForMessage.value.push(message.id)
   }
@@ -176,6 +187,15 @@ function showRepliesInqaBigView(message: Message, show: boolean) {
     qaBigViewShowRepliesForMessage.value = qaBigViewShowRepliesForMessage.value.filter(id => id != message.id)
   }
 }
+
+function refreshVotesMessageOrder() {
+  if (props.messageSortOrder == MessageSortOrder.VOTES) {
+    likeUserIdsPerMessageIdSnapshot.value = undefined
+    // Trigger reactivity to re-sort by creating a new array reference
+    messages.value = [...messages.value]
+  }
+}
+watch([() => props.messageAnswerFilter, () => props.messageSortOrder], () => refreshVotesMessageOrder())
 
 function addMessage(message: Message) {
   // ensure no duplicates in list
@@ -291,6 +311,7 @@ function markAnswered(message : Message) {
       errorMessagesStore.add(`Unable to update QA entry: ${result.error}`)
     }
   })
+  refreshVotesMessageOrder()
 }
 
 function scrollToEndOfList() {

--- a/src/components/talk/TalkQA.vue
+++ b/src/components/talk/TalkQA.vue
@@ -352,6 +352,10 @@ onMounted(() => {
 onUnmounted(() => {
   socket.off('qaEntries')
 })
+
+defineExpose({
+  refreshVotesMessageOrder
+})
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/talkQA/TalkQABigView.vue
+++ b/src/components/talkQA/TalkQABigView.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="qa-big-view">
-    <TalkQA :talk="talk" :qa-big-view="true" :messageAnswerFilter="messageAnswerFilter" :messageSortOrder="messageSortOrder"/>
+    <TalkQA ref="talkQARef" :talk="talk" :qa-big-view="true" :messageAnswerFilter="messageAnswerFilter" :messageSortOrder="messageSortOrder"/>
   </div>
 </template>
 
 <script setup lang="ts">
 import type { Talk } from '@/stores/talks'
 import TalkQA from '../talk/TalkQA.vue'
-import { onMounted, onUnmounted } from 'vue'
+import { onMounted, onUnmounted, ref } from 'vue'
 import socket from '@/util/socket'
 import type MessageAnswerFilter from '@/services/MessageAnswerFilter'
 import type MessageSortOrder from '@/services/MessageSortOrder'
@@ -18,11 +18,21 @@ const props = defineProps<{
   messageSortOrder: MessageSortOrder
 }>()
 
+const talkQARef = ref<InstanceType<typeof TalkQA>>()
+
+function refreshVotesMessageOrder() {
+  talkQARef.value?.refreshVotesMessageOrder()
+}
+
 onMounted(() => {
   socket.emit('roomEnter', props.talk.id)
 })
 onUnmounted(() => {
   socket.emit('roomLeave', props.talk.id)
+})
+
+defineExpose({
+  refreshVotesMessageOrder
 })
 </script>
 

--- a/src/views/TalkQAView.vue
+++ b/src/views/TalkQAView.vue
@@ -5,7 +5,9 @@
       <div class="btn-group">
         <button class="btn btn-outline-secondary" :class="{active:messageSortOrder==MessageSortOrder.CHRONOLOGICAL}"
             @click="messageSortOrder = MessageSortOrder.CHRONOLOGICAL">Chronological</button>
-        <button class="btn btn-outline-secondary" :class="{active:messageSortOrder==MessageSortOrder.VOTES}"
+        <button v-if="isMessageSortOrderVotes" class="btn btn-outline-secondary" :class="{active:messageSortOrder==MessageSortOrder.VOTES}"
+            @click="refreshVotesMessageOrder()">Votes ⟳</button>
+        <button v-else class="btn btn-outline-secondary" :class="{active:messageSortOrder==MessageSortOrder.VOTES}"
             @click="messageSortOrder = MessageSortOrder.VOTES">Votes</button>
       </div>
       <div class="btn-group">
@@ -34,6 +36,11 @@ const currentTalkId = computed(() => useCurrentTalkStore().talkId)
 const talk = computed(() => talkManager.getTalk(currentTalkId.value))
 const messageAnswerFilter = ref(MessageAnswerFilter.UNANSWERED)
 const messageSortOrder = ref(MessageSortOrder.CHRONOLOGICAL)
+const isMessageSortOrderVotes = computed(() => messageSortOrder.value === MessageSortOrder.VOTES)
+
+function refreshVotesMessageOrder() {
+
+}
 </script>
 
 <style lang="scss" scoped>

--- a/src/views/TalkQAView.vue
+++ b/src/views/TalkQAView.vue
@@ -40,6 +40,7 @@ const isMessageSortOrderVotes = computed(() => messageSortOrder.value === Messag
 const talkQABigViewRef = ref<InstanceType<typeof TalkQABigView>>()
 
 function refreshVotesMessageOrder() {
+  // if votes order is already active and button is hit again, force a sort order refresh
   talkQABigViewRef.value?.refreshVotesMessageOrder()
 }
 </script>

--- a/src/views/TalkQAView.vue
+++ b/src/views/TalkQAView.vue
@@ -18,7 +18,7 @@
       </div>
       <RouterLink to="/" class="btn">✕</RouterLink>
     </div>
-    <TalkQABigView :talk="talk" :messageAnswerFilter="messageAnswerFilter" :messageSortOrder="messageSortOrder" class="content" :key="talk.id"/>
+    <TalkQABigView ref="talkQABigViewRef" :talk="talk" :messageAnswerFilter="messageAnswerFilter" :messageSortOrder="messageSortOrder" class="content" :key="talk.id"/>
   </div>
 </template>
 
@@ -37,9 +37,10 @@ const talk = computed(() => talkManager.getTalk(currentTalkId.value))
 const messageAnswerFilter = ref(MessageAnswerFilter.UNANSWERED)
 const messageSortOrder = ref(MessageSortOrder.CHRONOLOGICAL)
 const isMessageSortOrderVotes = computed(() => messageSortOrder.value === MessageSortOrder.VOTES)
+const talkQABigViewRef = ref<InstanceType<typeof TalkQABigView>>()
 
 function refreshVotesMessageOrder() {
-
+  talkQABigViewRef.value?.refreshVotesMessageOrder()
 }
 </script>
 


### PR DESCRIPTION
when using the "Votes" ordering in the Q&A View, stick with the display order of talks even if likes are updated in realtime to keep the talk list stable. the like numbers per row are still updating in real-time, but the talk order does not change.

the talk order updates itself to the current like count when:
- the "Votes" button is hit again
- the talk ordering is changed
- a message is marked as answered
- switch between unanswered and answered view
- Q&A view is closed and opened again